### PR TITLE
add cross-platform build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
     - name: Docker Metadata action
       id: meta
       uses: docker/metadata-action@v3.5.0


### PR DESCRIPTION
add qemu and buildx to allow cross-platform builds

building for arm64 on gh-actions will fail without this