### PR TITLE
build patched userland for 64bit picamera

### DIFF
--- a/car.dockerfile
+++ b/car.dockerfile
@@ -1,3 +1,17 @@
+ARG BUILD_TAG=3.10-jammy-build-20230328
+FROM balenalib/raspberrypi4-64-ubuntu-python:${BUILD_TAG} as userland
+RUN install_packages \
+    cmake
+
+RUN git clone \
+    https://github.com/msherman64/userland \
+    -b wip/64bit \
+    /usr/local/src/userland
+WORKDIR /usr/local/src/userland
+RUN ./buildme --aarch64
+
+
+
 FROM --platform=linux/arm64/v8 kumatea/tensorflow:2.4.1-py39 AS base
 
 
@@ -35,5 +49,7 @@ RUN poetry install
 COPY --from=cargenerator /foocars/cars/chiaracer /foocars/cars/chiaracer
 #ENTRYPOINT ["python3"]
 #ENTRYPOINT ["/bin/bash"]
+COPY --from=userland /opt/vc/ /opt/vc/
+
 CMD ["/usr/local/bin/car_runner"]
 


### PR DESCRIPTION
this PR builds a patched version of userland for 64bit compatiblity.
Notably, it has some issues with MMAL, which is why the patches are not in mainline.
The following commits are reverted:
https://github.com/msherman64/userland/commit/e31da99739927e87707b2e1bc978e75653706b9c
https://github.com/msherman64/userland/commit/f97b1af1b3e653f9da2c1a3643479bfd469e3b74