### PR TITLE
ensure glibc version matches between userland and carrunner

### DIFF
--- a/car.dockerfile
+++ b/car.dockerfile
@@ -1,7 +1,12 @@
-ARG BUILD_TAG=3.10-jammy-build-20230328
-FROM balenalib/raspberrypi4-64-ubuntu-python:${BUILD_TAG} as userland
-RUN install_packages \
-    cmake
+ARG BASE_IMAGE=kumatea/tensorflow:2.4.1-py39
+
+FROM --platform=linux/arm64/v8 ${BASE_IMAGE} as userland
+
+RUN apt-get update && apt-get install -f -y \
+    cmake \
+    build-essential \
+    git \
+    sudo
 
 RUN git clone \
     https://github.com/msherman64/userland \
@@ -12,7 +17,7 @@ RUN ./buildme --aarch64
 
 
 
-FROM --platform=linux/arm64/v8 kumatea/tensorflow:2.4.1-py39 AS base
+FROM --platform=linux/arm64/v8 ${BASE_IMAGE} AS base
 
 
 WORKDIR foocars
@@ -50,6 +55,7 @@ COPY --from=cargenerator /foocars/cars/chiaracer /foocars/cars/chiaracer
 #ENTRYPOINT ["python3"]
 #ENTRYPOINT ["/bin/bash"]
 COPY --from=userland /opt/vc/ /opt/vc/
+ENV LD_LIBRARY_PATH=/opt/vc/lib
 
 CMD ["/usr/local/bin/car_runner"]
 


### PR DESCRIPTION
userland layer was pulling from a different OS version, and linked against a version of glibc that didn't match the one in the carrunner container.

Added an "ARG" to ensure that both layers build from the same base image.
Additionally, set env for LD_LIBRARY_PATH.

Verification of output:

```
# all linked libs are found
root@8ce1a6848940:/foocars/cars/carservices# ldd /opt/vc/bin/raspistill 
        linux-vdso.so.1 (0x0000ffffbcd99000)
        libmmal_core.so => /opt/vc/lib/libmmal_core.so (0x0000ffffbcd23000)
        libmmal_util.so => /opt/vc/lib/libmmal_util.so (0x0000ffffbcd00000)
        libmmal_vc_client.so => /opt/vc/lib/libmmal_vc_client.so (0x0000ffffbccdd000)
        libbcm_host.so => /opt/vc/lib/libbcm_host.so (0x0000ffffbccb2000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffffbcbf5000)
        libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffffbcbe1000)
        libvcsm.so => /opt/vc/lib/libvcsm.so (0x0000ffffbcbc4000)
        libvchiq_arm.so => /opt/vc/lib/libvchiq_arm.so (0x0000ffffbcbac000)
        libvcos.so => /opt/vc/lib/libvcos.so (0x0000ffffbcb8e000)
        libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffffbcb5f000)
        librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000ffffbcb47000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffffbc9d5000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffffbcd6b000)
```


```
# service at least gets far enough to complain about missing device, rather than some compatiblity error.
root@8ce1a6848940:/foocars/cars/carservices# /usr/local/bin/car_runner 
Traceback (most recent call last):
  File "/usr/local/bin/car_runner", line 3, in <module>
    from carservices.carRunner import main
  File "/foocars/cars/carservices/carservices/carRunner.py", line 4, in <module>
    import RPi.GPIO as GPIO
  File "/usr/local/lib/python3.9/site-packages/RPi/GPIO/__init__.py", line 23, in <module>
    from RPi._GPIO import *
RuntimeError: This module can only be run on a Raspberry Pi!
```